### PR TITLE
feat: consent mode v2

### DIFF
--- a/src/app/components/cookie-consent/cookie-consent.component.html
+++ b/src/app/components/cookie-consent/cookie-consent.component.html
@@ -1,0 +1,100 @@
+<!-- Modal -->
+<div
+  class="modal fade"
+  id="staticBackdrop"
+  data-bs-backdrop="static"
+  tabindex="-1"
+  [class.show]="showModal"
+  [style.display]="showModal ? 'block' : 'none'"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="staticBackdropLabel">Cookie Policy</h5>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+          (click)="hide()"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <div class="consent d-flex flex-column gap-3">
+          <div class="consent__option d-flex flex-column">
+            <div class="d-flex justify-content-between">
+              <div class="consent__description"><b>Analytics</b></div>
+              <div class="consent__switch">
+                <!-- Rounded switch -->
+                <label class="switch">
+                  <input
+                    type="checkbox"
+                    (change)="acceptAnalytics($event)"
+                    [checked]="consentService.analyticsConsentGiven$() | async"
+                  />
+                  <span class="slider round"></span>
+                </label>
+              </div>
+            </div>
+            <div>
+              Analytics cookies track site usage and trends to improve your
+              browsing experience. They gather anonymous data on how you
+              navigate and interact with the site.
+            </div>
+          </div>
+          <hr />
+          <div class="consent__option d-flex flex-column">
+            <div class="d-flex justify-content-between">
+              <div class="consent__description"><b>Measurement</b></div>
+              <div class="consent__switch">
+                <!-- Rounded switch -->
+                <label class="switch">
+                  <input
+                    type="checkbox"
+                    (change)="acceptMeasurement($event)"
+                    [checked]="
+                      consentService.measurementConsentGiven$() | async
+                    "
+                  />
+                  <span class="slider round"></span>
+                </label>
+              </div>
+            </div>
+            <div>Measurement</div>
+          </div>
+          <hr />
+          <div class="consent__option d-flex flex-column">
+            <div class="d-flex justify-content-between">
+              <div class="consent__description"><b>Audience</b></div>
+              <div class="consent__switch">
+                <!-- Rounded switch -->
+                <label class="switch">
+                  <input
+                    type="checkbox"
+                    (change)="acceptAudience($event)"
+                    [checked]="consentService.audienceConsentGiven$() | async"
+                  />
+                  <span class="slider round"></span>
+                </label>
+              </div>
+            </div>
+            <div>Audience</div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" (click)="hide()">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<fa-icon
+  class="cookie"
+  [icon]="faCookie"
+  size="2xl"
+  [class.show]="showCookieConsent"
+  [style.display]="showCookieConsent ? 'block' : 'none'"
+  (click)="switchModal()"
+></fa-icon>

--- a/src/app/components/cookie-consent/cookie-consent.component.scss
+++ b/src/app/components/cookie-consent/cookie-consent.component.scss
@@ -1,0 +1,70 @@
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 3rem;
+  height: 1.7rem;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 1.3rem;
+  width: 1.3rem;
+  left: 2px;
+  bottom: 3px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked+.slider {
+  background-color: #2196F3;
+}
+
+input:focus+.slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked+.slider:before {
+  -webkit-transform: translateX(23px);
+  -ms-transform: translateX(23px);
+  transform: translateX(23px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
+.cookie {
+  position: fixed;
+  left: 1rem;
+  bottom: 3rem;
+  z-index: 1000;
+  cursor: pointer;
+}

--- a/src/app/components/cookie-consent/cookie-consent.component.spec.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CookieConsentComponent } from './cookie-consent.component';
+
+describe('CookieConsentComponent', () => {
+  let component: CookieConsentComponent;
+  let fixture: ComponentFixture<CookieConsentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CookieConsentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/cookie-consent/cookie-consent.component.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.ts
@@ -1,0 +1,129 @@
+import { AfterViewInit, Component, Input } from '@angular/core';
+import { SharedModule } from '../../shared.module';
+import { faCookie } from '@fortawesome/free-solid-svg-icons';
+import { ConsentService } from '../../services/consent/consent.service';
+import { take, tap } from 'rxjs';
+
+@Component({
+  selector: 'app-cookie-consent',
+  standalone: true,
+  imports: [SharedModule],
+  templateUrl: './cookie-consent.component.html',
+  styleUrl: './cookie-consent.component.scss',
+})
+export class CookieConsentComponent implements AfterViewInit {
+  @Input() showModal: boolean = false;
+  @Input() showCookieConsent: boolean = false;
+
+  faCookie = faCookie;
+
+  constructor(public consentService: ConsentService) {
+    if (localStorage.getItem('consentPreferences')) {
+      this.consentService.setConsetPreferences(
+        JSON.parse(localStorage.getItem('consentPreferences') || '{}')
+      );
+    } else {
+      this.consentService.initConsentPreferences();
+    }
+  }
+
+  ngAfterViewInit() {
+    // need to update GTM consent preferences after the component is initialized
+    this.consentService.consentPreferences$
+      .pipe(
+        take(1),
+        tap((consentPreferences) => {
+          this.consentService.updateConsentPreferences(consentPreferences);
+        })
+      )
+      .subscribe();
+  }
+
+  hide() {
+    this.showModal = false;
+  }
+
+  show() {
+    this.showModal = true;
+  }
+
+  showCookieConsentIcon() {
+    this.showCookieConsent = true;
+  }
+
+  hideCookieConsentIcon() {
+    this.showCookieConsent = false;
+  }
+
+  acceptAnalytics(event: Event) {
+    const consent = (event.target as HTMLInputElement).checked;
+    console.log(`Analytics consent: ${consent}`);
+
+    if (consent) {
+      this.consentService.updateConsentPreferences({
+        ad_storage: true,
+        analytics_storage: true,
+        ad_user_data: true,
+        ad_personalization: false,
+      });
+    } else {
+      this.consentService.updateConsentPreferences({
+        ad_storage: false,
+        analytics_storage: false,
+        ad_user_data: false,
+        ad_personalization: false,
+      });
+    }
+  }
+
+  acceptMeasurement(event: Event) {
+    const consent = (event.target as HTMLInputElement).checked;
+    console.log(`Measurement consent: ${consent}`);
+    if (consent) {
+      this.consentService.updateConsentPreferences({
+        ad_storage: true,
+        ad_user_data: true,
+        analytics_storage: false,
+        ad_personalization: false,
+      });
+    } else {
+      this.consentService.updateConsentPreferences({
+        ad_storage: false,
+        ad_user_data: false,
+        analytics_storage: false,
+        ad_personalization: false,
+      });
+    }
+  }
+
+  acceptAudience(event: Event) {
+    const consent = (event.target as HTMLInputElement).checked;
+    console.log(`Audience consent: ${consent}`);
+    if (consent) {
+      this.consentService.updateConsentPreferences({
+        ad_storage: true,
+        ad_user_data: true,
+        ad_personalization: true,
+        analytics_storage: false,
+      });
+    } else {
+      this.consentService.updateConsentPreferences({
+        ad_storage: false,
+        ad_user_data: false,
+        ad_personalization: false,
+        analytics_storage: false,
+      });
+    }
+  }
+
+  acceptCookies(event: Event) {
+    this.acceptMeasurement(event);
+    this.acceptAudience(event);
+    this.acceptAnalytics(event);
+    this.hide();
+  }
+
+  switchModal() {
+    this.showModal = !this.showModal;
+  }
+}

--- a/src/app/services/consent/consent.service.spec.ts
+++ b/src/app/services/consent/consent.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConsentService } from './consent.service';
+
+describe('ConsentService', () => {
+  let service: ConsentService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConsentService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/consent/consent.service.ts
+++ b/src/app/services/consent/consent.service.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, map } from 'rxjs';
+
+interface ConsentPreferences {
+  analytics_storage: boolean;
+  ad_storage: boolean;
+  ad_user_data: boolean;
+  ad_personalization: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ConsentService {
+  consentPreferencesSubject = new BehaviorSubject<ConsentPreferences>({
+    analytics_storage: false,
+    ad_storage: false,
+    ad_user_data: false,
+    ad_personalization: false,
+  });
+
+  consentPreferences$ = this.consentPreferencesSubject.asObservable();
+
+  constructor() {}
+
+  initConsentPreferences() {
+    const initialConsentPreferences = {
+      analytics_storage: false,
+      ad_storage: false,
+      ad_user_data: false,
+      ad_personalization: false,
+    };
+
+    this.setConsetPreferences(initialConsentPreferences);
+  }
+
+  setConsetPreferences(consentPreferences: ConsentPreferences) {
+    localStorage.setItem(
+      'consentPreferences',
+      JSON.stringify(consentPreferences)
+    );
+    this.consentPreferencesSubject.next(consentPreferences);
+  }
+
+  analyticsConsentGiven$() {
+    return this.consentPreferences$.pipe(
+      map(
+        (consentOptions) =>
+          consentOptions.analytics_storage &&
+          consentOptions.ad_storage &&
+          consentOptions.ad_user_data
+      )
+    );
+  }
+
+  measurementConsentGiven$() {
+    return this.consentPreferences$.pipe(
+      map(
+        (consentOptions) =>
+          consentOptions.ad_storage && consentOptions.ad_user_data
+      )
+    );
+  }
+
+  audienceConsentGiven$() {
+    return this.consentPreferences$.pipe(
+      map(
+        (consentOptions) =>
+          consentOptions.ad_storage &&
+          consentOptions.ad_user_data &&
+          consentOptions.ad_personalization
+      )
+    );
+  }
+
+  getConsentPreferences() {
+    return JSON.parse(localStorage.getItem('consentPreferences') || '{}');
+  }
+
+  updateConsentPreferences(consentPreferences: ConsentPreferences) {
+    this.setConsetPreferences(consentPreferences);
+
+    const consentPreferencesDataLayer = {
+      ad_storage: consentPreferences.ad_storage ? 'granted' : 'denied',
+      analytics_storage: consentPreferences.analytics_storage
+        ? 'granted'
+        : 'denied',
+      ad_user_data: consentPreferences.ad_user_data ? 'granted' : 'denied',
+      ad_personalization: consentPreferences.ad_personalization
+        ? 'granted'
+        : 'denied',
+    };
+
+    window.dataLayer.push({
+      event: 'update_consent',
+      ...consentPreferencesDataLayer,
+    });
+  }
+}

--- a/src/app/views/main/main.component.html
+++ b/src/app/views/main/main.component.html
@@ -48,4 +48,8 @@
   } @placeholder {
   <div>Loading..</div>
   }
+  <app-cookie-consent
+    [showModal]="true"
+    [showCookieConsent]="true"
+  ></app-cookie-consent>
 </div>

--- a/src/app/views/main/main.component.ts
+++ b/src/app/views/main/main.component.ts
@@ -1,14 +1,25 @@
-import { Component } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import { CarouselComponent } from '../../components/carousel/carousel.component';
 import { DisclaimerComponent } from '../../components/disclaimer/disclaimer.component';
 import { SharedModule } from '../../shared.module';
-import { faHome, faGlobe, faTag } from '@fortawesome/free-solid-svg-icons';
+import {
+  faHome,
+  faGlobe,
+  faTag,
+  faCookie,
+} from '@fortawesome/free-solid-svg-icons';
 import { NavigationService } from 'src/app/services/navigation/navigation.service';
+import { CookieConsentComponent } from 'src/app/components/cookie-consent/cookie-consent.component';
 
 @Component({
   selector: 'app-main',
   standalone: true,
-  imports: [SharedModule, CarouselComponent, DisclaimerComponent],
+  imports: [
+    SharedModule,
+    CarouselComponent,
+    DisclaimerComponent,
+    CookieConsentComponent,
+  ],
   templateUrl: './main.component.html',
   styleUrls: ['./main.component.scss'],
 })
@@ -16,6 +27,10 @@ export class MainComponent {
   faHome = faHome;
   faGlobe = faGlobe;
   faTag = faTag;
+  faCookie = faCookie;
+  showCookieConsent: boolean = false;
+  @ViewChild(CookieConsentComponent)
+  cookieConsentComponent!: CookieConsentComponent;
 
   constructor(private navigationService: NavigationService) {}
 


### PR DESCRIPTION
1. Add a cookie icon on the bottom left to open the consent modal.
2. Add a BootStrap 5 modal before users browse the website.
3. Add a consent service to handle consent preference with localStorage.