### PR TITLE
fix: consent modal showing state

### DIFF
--- a/src/app/components/cookie-consent/cookie-consent.component.html
+++ b/src/app/components/cookie-consent/cookie-consent.component.html
@@ -82,8 +82,12 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary" (click)="hide()">
-            Close
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="hide(); consent()"
+          >
+            Confirm
           </button>
         </div>
       </div>

--- a/src/app/components/cookie-consent/cookie-consent.component.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.ts
@@ -126,4 +126,8 @@ export class CookieConsentComponent implements AfterViewInit {
   switchModal() {
     this.showModal = !this.showModal;
   }
+
+  consent() {
+    this.consentService.hasConsent();
+  }
 }

--- a/src/app/services/consent/consent.service.ts
+++ b/src/app/services/consent/consent.service.ts
@@ -20,6 +20,8 @@ export class ConsentService {
   });
 
   consentPreferences$ = this.consentPreferencesSubject.asObservable();
+  consentSubject = new BehaviorSubject<boolean>(false);
+  consent$ = this.consentSubject.asObservable();
 
   constructor() {}
 
@@ -95,5 +97,9 @@ export class ConsentService {
       event: 'update_consent',
       ...consentPreferencesDataLayer,
     });
+  }
+
+  hasConsent() {
+    this.consentSubject.next(true);
   }
 }

--- a/src/app/views/main/main.component.html
+++ b/src/app/views/main/main.component.html
@@ -49,7 +49,7 @@
   <div>Loading..</div>
   }
   <app-cookie-consent
-    [showModal]="true"
+    [showModal]="showCookieModal"
     [showCookieConsent]="true"
   ></app-cookie-consent>
 </div>

--- a/src/app/views/main/main.component.ts
+++ b/src/app/views/main/main.component.ts
@@ -8,8 +8,10 @@ import {
   faTag,
   faCookie,
 } from '@fortawesome/free-solid-svg-icons';
-import { NavigationService } from 'src/app/services/navigation/navigation.service';
-import { CookieConsentComponent } from 'src/app/components/cookie-consent/cookie-consent.component';
+import { NavigationService } from '../../services/navigation/navigation.service';
+import { CookieConsentComponent } from '../../components/cookie-consent/cookie-consent.component';
+import { ConsentService } from '../../services/consent/consent.service';
+import { take, tap } from 'rxjs';
 
 @Component({
   selector: 'app-main',
@@ -23,16 +25,34 @@ import { CookieConsentComponent } from 'src/app/components/cookie-consent/cookie
   templateUrl: './main.component.html',
   styleUrls: ['./main.component.scss'],
 })
-export class MainComponent {
+export class MainComponent implements AfterViewInit {
   faHome = faHome;
   faGlobe = faGlobe;
   faTag = faTag;
   faCookie = faCookie;
-  showCookieConsent: boolean = false;
+  showCookieModal: boolean = false;
   @ViewChild(CookieConsentComponent)
   cookieConsentComponent!: CookieConsentComponent;
 
-  constructor(private navigationService: NavigationService) {}
+  constructor(
+    private navigationService: NavigationService,
+    private consentService: ConsentService
+  ) {}
+
+  ngAfterViewInit(): void {
+    this.consentService.consent$
+      .pipe(
+        take(1),
+        tap((consent) => {
+          if (consent) {
+            this.showCookieModal = false;
+          } else {
+            this.showCookieModal = true;
+          }
+        })
+      )
+      .subscribe();
+  }
 
   navigateToDestinations() {
     this.navigationService.navigateToDestinations();


### PR DESCRIPTION
1. Use another state to show cookie modal when first visiting.
2. Change naming from close to confirm.
3. Adjust consent service accordingly.