### PR TITLE
fix: manual video tracking without enhaced measurement

### DIFF
--- a/src/app/components/cookie-consent/cookie-consent.component.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.ts
@@ -1,4 +1,9 @@
-import { AfterViewInit, Component, Input } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+} from '@angular/core';
 import { SharedModule } from '../../shared.module';
 import { faCookie } from '@fortawesome/free-solid-svg-icons';
 import { ConsentService } from '../../services/consent/consent.service';
@@ -10,6 +15,7 @@ import { take, tap } from 'rxjs';
   imports: [SharedModule],
   templateUrl: './cookie-consent.component.html',
   styleUrl: './cookie-consent.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CookieConsentComponent implements AfterViewInit {
   @Input() showModal: boolean = false;

--- a/src/app/services/youtube/youtube.service.spec.ts
+++ b/src/app/services/youtube/youtube.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { YoutubeService } from './youtube.service';
+
+describe('YoutubeService', () => {
+  let service: YoutubeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(YoutubeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/youtube/youtube.service.ts
+++ b/src/app/services/youtube/youtube.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, OnDestroy } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class YoutubeService implements OnDestroy {
+  private progressInterval: any;
+  private youtubeEventRecords: Map<number, boolean> = new Map();
+  constructor() {}
+
+  trackVideoEvent(event: any): void {
+    const playerState = event.target.getPlayerState();
+    switch (playerState) {
+      case -1:
+        console.log('Video Unstarted');
+        break;
+      case 0:
+        console.log('Video Ended');
+        window.dataLayer.push({
+          event: 'youtube_complete',
+          videoTitle: event.target.videoTitle,
+          videoUrl: event.target.getVideoUrl(),
+          videoPercent: 100,
+        });
+        break;
+      case 1:
+        console.log('Video Playing');
+        this.startProgressTracking(event);
+        break;
+      case 2:
+        console.log('Video Paused');
+        break;
+      case 3:
+        console.log('Video Buffering');
+        break;
+      case 5:
+        console.log('Video Cued');
+        window.dataLayer.push({
+          event: 'youtube_start',
+          videoTitle: event.target.videoTitle,
+          videoUrl: event.target.getVideoUrl(),
+          videoPercent:
+            event.target.getCurrentTime() / event.target.getDuration(),
+        });
+        break;
+      default:
+        console.log('Video State Unknown');
+        break;
+    }
+  }
+
+  startProgressTracking(event: any): void {
+    // Clear existing interval if any
+    this.stopProgressTracking();
+
+    // Set up a new interval
+    this.progressInterval = setInterval(() => {
+      this.trackVideoProgress(event);
+    }, 1000); // Adjust interval as needed
+  }
+
+  stopProgressTracking(): void {
+    if (this.progressInterval) {
+      clearInterval(this.progressInterval);
+      this.progressInterval = null;
+    }
+  }
+
+  trackVideoProgress(event: any): void {
+    const videoPercent =
+      event.target.getCurrentTime() / event.target.getDuration();
+    this.checkAndTrackProgress(
+      25,
+      videoPercent >= 0.25 && videoPercent < 0.5,
+      event
+    );
+    this.checkAndTrackProgress(
+      50,
+      videoPercent >= 0.5 && videoPercent < 0.75,
+      event
+    );
+    this.checkAndTrackProgress(
+      75,
+      videoPercent >= 0.75 && videoPercent < 0.9,
+      event
+    );
+  }
+
+  private checkAndTrackProgress(
+    label: number,
+    condition: boolean,
+    event: any
+  ): void {
+    if (condition && !this.youtubeEventRecords.get(label)) {
+      console.log(`Video Progress ${label}`);
+      this.youtubeEventRecords.set(label, true);
+      window.dataLayer.push({
+        event: 'youtube_progress',
+        videoTitle: event.target.videoTitle,
+        videoUrl: event.target.getVideoUrl(),
+        videoPercent: label,
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    // Ensure we clean up
+    this.stopProgressTracking();
+  }
+}

--- a/src/app/views/destination/destination.component.html
+++ b/src/app/views/destination/destination.component.html
@@ -73,7 +73,7 @@
               (click)="showModal(destination.video)"
               >Video</a
             >
-            @if (showVideoPlayer) {
+            @if (videoId === getVideoId(destination.video)) {
             <div
               #ytPlayerModal
               id="yt-player-modal"
@@ -91,6 +91,7 @@
                   class="video-player"
                   [videoId]="videoId"
                   [playerVars]="playerVars"
+                  (stateChange)="onStateChange($event)"
                   disablePlaceholder="true"
                   placeholderButtonLabel="destination intro video"
                 />

--- a/src/app/views/destination/destination.component.ts
+++ b/src/app/views/destination/destination.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ElementRef,
+  Type,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -9,9 +10,10 @@ import { SharedService } from '../../services/shared/shared.service';
 import { WindowSizeService } from '../../services/window-size/window-size.service';
 import { NavigationService } from '../../../app/services/navigation/navigation.service';
 import { FormControl, FormGroup } from '@angular/forms';
-import { SharedModule } from 'src/app/shared.module';
-import { SearchService } from 'src/app/services/search/search.service';
+import { SharedModule } from '../../shared.module';
+import { SearchService } from '../../services/search/search.service';
 import { YouTubePlayerModule } from '@angular/youtube-player';
+import { YoutubeService } from '../../services/youtube/youtube.service';
 
 @Component({
   selector: 'app-destination',
@@ -29,6 +31,7 @@ export class DestinationComponent {
 
   @ViewChild('ytPlayerModal') ytPlayerModal!: ElementRef;
   @ViewChild('player') videoPlayer: any;
+  currentComponent: Type<any> | null = null;
   videoId = '';
   showVideoPlayer = false;
   playerVars = {
@@ -40,7 +43,8 @@ export class DestinationComponent {
     public sharedService: SharedService,
     public windowSizeService: WindowSizeService,
     private navigationService: NavigationService,
-    public searchService: SearchService
+    public searchService: SearchService,
+    private youtubeService: YoutubeService
   ) {}
 
   navigateToHome() {
@@ -71,13 +75,22 @@ export class DestinationComponent {
     return url.split('/')[url.split('/').length - 1];
   }
 
+  get currentVideoId(): string {
+    return this.videoId;
+  }
+
   closeModal() {
     this.showVideoPlayer = false;
     this.videoPlayer.pauseVideo();
+    this.youtubeService.stopProgressTracking();
   }
 
   showModal(url: string) {
     this.videoId = this.getVideoId(url);
     this.showVideoPlayer = true;
+  }
+
+  onStateChange(event: any) {
+    this.youtubeService.trackVideoEvent(event);
   }
 }

--- a/src/app/views/main/main.component.ts
+++ b/src/app/views/main/main.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { CarouselComponent } from '../../components/carousel/carousel.component';
 import { DisclaimerComponent } from '../../components/disclaimer/disclaimer.component';
 import { SharedModule } from '../../shared.module';
@@ -25,12 +25,12 @@ import { take, tap } from 'rxjs';
   templateUrl: './main.component.html',
   styleUrls: ['./main.component.scss'],
 })
-export class MainComponent implements AfterViewInit {
+export class MainComponent implements OnInit {
   faHome = faHome;
   faGlobe = faGlobe;
   faTag = faTag;
   faCookie = faCookie;
-  showCookieModal: boolean = false;
+  showCookieModal!: boolean;
   @ViewChild(CookieConsentComponent)
   cookieConsentComponent!: CookieConsentComponent;
 
@@ -39,7 +39,7 @@ export class MainComponent implements AfterViewInit {
     private consentService: ConsentService
   ) {}
 
-  ngAfterViewInit(): void {
+  ngOnInit(): void {
     this.consentService.consent$
       .pipe(
         take(1),


### PR DESCRIPTION
1. Uiltize YouTube iframe API to fire GTM tags, and add YouTube service accordingly.
2. Use OnPush detection to improve performance on the cookie consent modal.
3. Fix the NG0100 error on the main component.

Because enhanced measurement will collect data no matter in the website or app environment, the amended implementation ensures it is not automatically collected and it fires events manually.