### PR TITLE
fix: scroll tracking

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,5 +7,5 @@
 <app-footer></app-footer>
 <app-disclaimer></app-disclaimer>
 } @placeholder {
-<div>Loading..</div>
+<div #loadingDiv>Loading..</div>
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,11 @@
 import { CookieService } from './services/cookie/cookie.service';
-import { Component, OnInit } from '@angular/core';
+import {
+  AfterViewChecked,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { NavbarComponent } from './components/navbar/navbar.component';
@@ -7,8 +13,9 @@ import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { DisclaimerComponent } from './components/disclaimer/disclaimer.component';
 import { AuthService } from './services/auth/auth.service';
-import { take, tap } from 'rxjs';
+import { Subject, first, take, tap } from 'rxjs';
 import { UrlTrackerService } from './services/url-tracker/url-tracker.service';
+import { LoadingService } from './services/loading/loading.service';
 
 @Component({
   selector: 'app-root',
@@ -24,13 +31,16 @@ import { UrlTrackerService } from './services/url-tracker/url-tracker.service';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewChecked {
   title = 'ng-gtm-site';
+  @ViewChild('loadingDiv', { static: false }) loadingDiv!: ElementRef;
+  private destroy$ = new Subject<void>();
 
   constructor(
     private cookieService: CookieService,
     private authService: AuthService,
-    private urlTrackerService: UrlTrackerService
+    private urlTrackerService: UrlTrackerService,
+    private loadingService: LoadingService
   ) {}
 
   ngOnInit() {
@@ -50,6 +60,36 @@ export class AppComponent implements OnInit {
       )
       .subscribe();
 
+    this.loadingService
+      .getLoadingState()
+      .pipe(
+        first((isLoading) => !isLoading),
+        tap((isLoading) => {
+          if (!isLoading) {
+            window.dataLayer.push({
+              event: 'componentsLoaded',
+            });
+          }
+        })
+      )
+      .subscribe();
     this.urlTrackerService.initializeUrlTracking();
+  }
+
+  ngAfterViewChecked() {
+    try {
+      if (this.loadingDiv.nativeElement) {
+        this.loadingService.setLoadingState(true);
+      }
+    } catch (error) {
+      // loadingDiv is no longer available
+      this.loadingService.setLoadingState(false);
+    }
+  }
+
+  ngOnDestroy() {
+    // Cleanup subscriptions
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/services/loading/loading.service.spec.ts
+++ b/src/app/services/loading/loading.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadingService } from './loading.service';
+
+describe('LoadingService', () => {
+  let service: LoadingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoadingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/loading/loading.service.ts
+++ b/src/app/services/loading/loading.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoadingService {
+  private loadingState = new BehaviorSubject<boolean>(true);
+
+  setLoadingState(isLoading: boolean) {
+    this.loadingState.next(isLoading);
+  }
+
+  getLoadingState(): Observable<boolean> {
+    return this.loadingState.asObservable();
+  }
+}


### PR DESCRIPTION
Detecting the page to be fully loaded is to fix the scroll tracking issue. Since the scroll tracking script loads after history changes, those deferred components cause the scroll depth to be always 100%.